### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/aaronfelkai/eebea2aa-b5d4-4fdd-a3f8-02c5df56ae46/2b8a69ec-954b-423a-b1bd-9d077e86deb1/_apis/work/boardbadge/7c76c6f4-471e-4788-bd8a-135494b162d4)](https://dev.azure.com/aaronfelkai/eebea2aa-b5d4-4fdd-a3f8-02c5df56ae46/_boards/board/t/2b8a69ec-954b-423a-b1bd-9d077e86deb1/Microsoft.RequirementCategory)
 # AaronCodeLib
 Code Library


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/aaronfelkai/eebea2aa-b5d4-4fdd-a3f8-02c5df56ae46/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.